### PR TITLE
Add timeout to acquireAndWait() method

### DIFF
--- a/firmware/PietteTech_DHT.cpp
+++ b/firmware/PietteTech_DHT.cpp
@@ -133,9 +133,21 @@ int PietteTech_DHT::acquire() {
         return DHTLIB_ERROR_ACQUIRING;
 }
 
-int PietteTech_DHT::acquireAndWait() {
+int PietteTech_DHT::acquireAndWait(uint32_t timeout=0) {
     acquire();
-    while(acquiring()) ;
+    uint32_t start = millis();
+    uint32_t wrapper;
+    while(acquiring() && (timeout == 0 || (millis() > start && (millis-start) < timeout));
+    if (timeout)
+    {
+        if (millis < start) // millis counter wrapped
+        {
+            wrapper = (~start)+1;   // Compute elapsed seconds between "start" and counter-wrap to 0
+            timeout -= wrapper;     // Subtract elapsed seconds to 0 from timeout
+        }
+        // If millis counter didn't wrap, the next line will be a no-op.
+        while(acquiring() && millis < timeout);
+    }
     return getStatus();
 }
 

--- a/firmware/PietteTech_DHT.cpp
+++ b/firmware/PietteTech_DHT.cpp
@@ -22,7 +22,7 @@
 /*
     Timing of DHT22 SDA signal line after MCU pulls low for 1ms
     https://github.com/mtnscott/Spark_DHT/AM2302.pdf
- 
+
   - - - -            -----           -- - - --            ------- - -
          \          /     \         /  \      \          /
           +        /       +       /    +      +        /
@@ -30,7 +30,7 @@
             ------           -----        -- - --------
  ^        ^                ^                   ^          ^
  |   Ts   |        Tr      |        Td         |    Te    |
- 
+
     Ts : Start time from MCU changing SDA from Output High to Tri-State (Hi-Z)
          Spec: 20-200us             Tested: < 65us
     Tr : DHT response to MCU controlling SDA and pulling Low and High to
@@ -83,7 +83,7 @@ int PietteTech_DHT::acquire() {
         // return last correct measurement, (this read time - last read time) < device limit
         return DHTLIB_ACQUIRED;
     }
-    
+
     if (_state == STOPPED || _state == ACQUIRED) {
         /*
          * Setup the initial state machine
@@ -137,16 +137,16 @@ int PietteTech_DHT::acquireAndWait(uint32_t timeout=0) {
     acquire();
     uint32_t start = millis();
     uint32_t wrapper;
-    while(acquiring() && (timeout == 0 || (millis() > start && (millis-start) < timeout));
+    while(acquiring() && (timeout == 0 || (millis() > start && (millis()-start) < timeout)));
     if (timeout)
     {
-        if (millis < start) // millis counter wrapped
+        if (millis() < start) // millis counter wrapped
         {
             wrapper = (~start)+1;   // Compute elapsed seconds between "start" and counter-wrap to 0
             timeout -= wrapper;     // Subtract elapsed seconds to 0 from timeout
         }
         // If millis counter didn't wrap, the next line will be a no-op.
-        while(acquiring() && millis < timeout);
+        while(acquiring() && (millis() < timeout));
     }
     return getStatus();
 }

--- a/firmware/PietteTech_DHT.h
+++ b/firmware/PietteTech_DHT.h
@@ -65,7 +65,7 @@ public:
     void begin(uint8_t sigPin, uint8_t dht_type, void (*isrCallback_wrapper)());
     void isrCallback();
     int acquire();
-    int acquireAndWait();
+    int acquireAndWait(uint32_t);
     float getCelsius();
     float getFahrenheit();
     float getKelvin();
@@ -79,11 +79,11 @@ public:
 #if defined(DHT_DEBUG_TIMING)
     volatile uint8_t _edges[41];
 #endif
-    
+
 private:
     void (*isrCallback_wrapper)(void);
     void convert();
-    
+
     enum states{RESPONSE=0,DATA=1,ACQUIRED=2,STOPPED=3,ACQUIRING=4};
     volatile states _state;
     volatile int _status;


### PR DESCRIPTION
The proposed changes implement a timeout argument to acquireAndWait() in a manner compatible with existing behavior of the library. If timeout=0 or no timeout is specified, default is to wait until acquisition finishes even if it never does.

If timeout is given a non-zero value, then the function will return when acquisition finishes or after timeout milliseconds, whichever occurs first. The timeout function is written in such a way that it should handle millis() counter wraps.

I've done basic testing of this code in my application and it appears to work.
