### PR TITLE
Bumped version number

### DIFF
--- a/spark.json
+++ b/spark.json
@@ -1,6 +1,6 @@
 {
     "name": "PietteTech_DHT",
-    "version": "0.0.3",
+    "version": "0.0.4",
     "author": "Scott Piette scott.piette@gmail.com",
     "license": "GPL v3 (http://www.gnu.org/licenses/gpl.html)",
     "description": "Interrupt driven DHT11/21/22 Sensor library"


### PR DESCRIPTION
Bumped the version number so the code can be updated at build.particle.io. At the time of writing, the timeout functionality is not available because the version number stayed the same.